### PR TITLE
Bump Misk, Wisp

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,9 +3,9 @@ package hotwire_kt
 object Versions {
   val kotlin = "1.6.21"
   val moshi = "1.13.0"
-  val misk = "0.25.0-20221111.2009-4017c52"
+  val misk = "0.25.0-20221209.0052-70e8a94"
   val retrofit = "2.9.0"
   val sqldelight = "1.5.3"
   val wire = "4.4.2"
-  val wisp = "1.2.2"
+  val wisp = "1.2.4"
 }


### PR DESCRIPTION
Unfortunately retries are still needed for Github Actions CI though locally the Misk fix has stopped flakey first run of DB tests.